### PR TITLE
Documentation suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,8 +287,8 @@ https://cloud.google.com/ml-engine/docs/packaging-trainer
 #### Running the job locally
 It is best practice to test training your job locally (usually on a sample of 
 data) to ensure your packaged code is working before submitting your job to run 
-on AI Platform. Make sure to run this from the location of your repo. The 
-command structure for this is:
+on AI Platform. Make sure to run this from the location of your repo and ensure 
+all required packages have been installed. The command structure for this is:
 
 ##### Authentication:
 When running locally, make sure that you are first authenticated. 
@@ -328,6 +328,9 @@ python code specific to the model.py code in the trainer for this repo. In
 order to make the training code work for both local training and submitting to 
 AI Platform, we need to have the user defined bucket parameter here, but it can 
 be set to None when running locally.
+
+Refer to the Helpful Links (above) for more information on each of the job 
+parameters used here.
 
 ``` 
 gcloud ai-platform local train  

--- a/README.md
+++ b/README.md
@@ -281,8 +281,8 @@ out to a bucket. Below is documentation for that process, as well as
 issues/gotchas found along the way. 
 
 Helpful Links:
-https://cloud.google.com/ml-engine/docs/training-jobs
-https://cloud.google.com/ml-engine/docs/packaging-trainer
+https://cloud.google.com/ai-platform/training/docs/training-jobs
+https://cloud.google.com/ai-platform/training/docs/packaging-trainer
 
 #### Running the job locally
 It is best practice to test training your job locally (usually on a sample of 


### PR DESCRIPTION
After using the documentation to run a job locally, I am suggesting a couple updates to documentation. These include explicitly calling out that all required packages need to be installed and calling out that the helpful links include information more information on how the job parameters should be used. I also updated the Helpful Links to point to ai-platform documentation instead of depricated ml-engine (the old links still worked but wanted to update ml-engine syntax)